### PR TITLE
remove @Generated from generate classes

### DIFF
--- a/editors-processor/pom.xml
+++ b/editors-processor/pom.xml
@@ -13,10 +13,10 @@
     <name>GWT Editors Processor</name>
 
     <properties>
-        <javapoet.version>1.11.1</javapoet.version>
-        <auto.common.version>0.8</auto.common.version>
-        <auto.service.version>1.0-rc2</auto.service.version>
-        <compile.testing.version>0.9</compile.testing.version>
+        <javapoet.version>1.12.1</javapoet.version>
+        <auto.common.version>0.10</auto.common.version>
+        <auto.service.version>1.0-rc6</auto.service.version>
+        <compile.testing.version>0.18</compile.testing.version>
         <org.truth.version>0.23</org.truth.version>
     </properties>
 

--- a/editors-processor/src/main/java/org/gwtproject/editor/processor/DriverProcessingStep.java
+++ b/editors-processor/src/main/java/org/gwtproject/editor/processor/DriverProcessingStep.java
@@ -23,7 +23,6 @@ import com.squareup.javapoet.*;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.*;
-import javax.annotation.Generated;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.FilerException;
 import javax.annotation.processing.Messager;
@@ -172,10 +171,13 @@ public class DriverProcessingStep implements ProcessingStep {
         TypeSpec.classBuilder(typeName)
             .addOriginatingElement(interfaceToImplement)
             .addModifiers(Modifier.PUBLIC)
-            .addAnnotation(
-                AnnotationSpec.builder(Generated.class)
-                    .addMember("value", "\"$L\"", DriverProcessor.class.getCanonicalName())
-                    .build())
+            // Once GWT supports the new package of the Generated class
+            // we can uncomment this code
+            //            .addAnnotation(
+            //                AnnotationSpec.builder(getGeneratedClassName())
+            //                    .addMember("value", "\"$L\"",
+            // DriverProcessor.class.getCanonicalName())
+            //                    .build())
             .addSuperinterface(TypeName.get(interfaceToImplement.asType()))
             .superclass(
                 ParameterizedTypeName.get(
@@ -213,10 +215,13 @@ public class DriverProcessingStep implements ProcessingStep {
               .addOriginatingElement(types.asElement(data.getEditedType()))
               .addOriginatingElement(types.asElement(data.getEditorType()))
               .addModifiers(Modifier.PUBLIC)
-              .addAnnotation(
-                  AnnotationSpec.builder(Generated.class)
-                      .addMember("value", "\"$L\"", DriverProcessor.class.getCanonicalName())
-                      .build())
+              // Once GWT supports the new package of the Generated class
+              // we can uncomment this code
+              //              .addAnnotation(
+              //                  AnnotationSpec.builder(getGeneratedClassName())
+              //                      .addMember("value", "\"$L\"",
+              // DriverProcessor.class.getCanonicalName())
+              //                      .build())
               .superclass(getEditorDelegateType()); // raw type here, for the same reason as above
 
       NameFactory names = new NameFactory();
@@ -374,10 +379,13 @@ public class DriverProcessingStep implements ProcessingStep {
               .addOriginatingElement(types.asElement(parent.getEditedType())) // bean
               .addOriginatingElement(types.asElement(data.getEditedType())) // child
               .addModifiers(Modifier.PUBLIC)
-              .addAnnotation(
-                  AnnotationSpec.builder(Generated.class)
-                      .addMember("value", "\"$L\"", DriverProcessor.class.getCanonicalName())
-                      .build())
+              // Once GWT supports the new package of the Generated class
+              // we can uncomment this code
+              //                  .addAnnotation(
+              //                  AnnotationSpec.builder(getGeneratedClassName())
+              //                      .addMember("value", "\"$L\"",
+              // DriverProcessor.class.getCanonicalName())
+              //                      .build())
               .superclass(
                   ParameterizedTypeName.get(
                       ClassName.get(AbstractEditorContext.class),
@@ -508,4 +516,15 @@ public class DriverProcessingStep implements ProcessingStep {
     ClassName.get(interfaceToImplement).simpleNames().forEach(joiner::add);
     return joiner.toString();
   }
+
+  // Once GWT supports the new package of the Generated class
+  // we can uncomment this code
+  //  private ClassName getGeneratedClassName() {
+  //    String version = System.getProperty("java.version");
+  //    if (version.startsWith("1.")) {
+  //      return ClassName.get("javax.annotation", "Generated");
+  //    } else {
+  //      return ClassName.get("javax.annotation.processing", "Generated");
+  //    }
+  //  }
 }

--- a/editors/pom.xml
+++ b/editors/pom.xml
@@ -47,7 +47,7 @@
             <plugin>
                 <groupId>net.ltgt.gwt.maven</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
-                <version>1.0-rc-9</version>
+                <version>1.0.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <moduleName>org.gwtproject.editor.Editor</moduleName>


### PR DESCRIPTION
Starting with Java 9 the `Generated` class has moved from `javax.annotation` to `javax.anotation.processing`. The processor of gwt-editors always generated the import statement using the `javax.annotation` package. 

This works for GWT in Java 8 and Java 11. In j2cl gwt-editors can only be used with Java 8. Using a newer Java version will create a `ClassNotException`(which is correct).

Generating the package depending on the Java version, works for j2cl. But then, gwt-editors will only work with  Java 8 and GWT. Using a newer Java version with GWT and gwt-editors will fail.

At the moment, the only solution to get gwt-editors working with j2cl & GWT and all Java versions is to avoid generating the annotation. In my opinion this is ok, cause the annotation is more or less only for documentation.